### PR TITLE
Make the entire squares clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,10 @@
     cursor: pointer;
   }
 
+  td.selected {
+    background-color: #6fdDB1;
+  }
+
   a.selected {
     font-weight: bold;
   }

--- a/index.html
+++ b/index.html
@@ -132,89 +132,39 @@
   <h4>A cynical ray of sunshine in your bleak, miserable travel experience</h4>
   <table cellpadding="0" cellspacing="0">
     <tr>
-      <td>
-        <a id="square0-0"></a>
-      </td>
-      <td>
-        <a id="square0-1"></a>
-      </td>
-      <td>
-        <a id="square0-2"></a>
-      </td>
-      <td>
-        <a id="square0-3"></a>
-      </td>
-      <td>
-        <a id="square0-4"></a>
-      </td>
+      <td id="square0-0"></td>
+      <td id="square0-1"></td>
+      <td id="square0-2"></td>
+      <td id="square0-3"></td>
+      <td id="square0-4"></td>
     </tr>
     <tr>
-      <td>
-        <a id="square1-0"></a>
-      </td>
-      <td>
-        <a id="square1-1"></a>
-      </td>
-      <td>
-        <a id="square1-2"></a>
-      </td>
-      <td>
-        <a id="square1-3"></a>
-      </td>
-      <td>
-        <a id="square1-4"></a>
-      </td>
+      <td id="square1-0"></td>
+      <td id="square1-1"></td>
+      <td id="square1-2"></td>
+      <td id="square1-3"></td>
+      <td id="square1-4"></td>
     </tr>
     <tr>
-      <td>
-        <a id="square2-0"></a>
-      </td>
-      <td>
-        <a id="square2-1"></a>
-      </td>
-      <td>
-        <a id="square2-2"></a>
-      </td>
-      <td>
-        <a id="square2-3"></a>
-      </td>
-      <td>
-        <a id="square2-4"></a>
-      </td>
+      <td id="square2-0"></td>
+      <td id="square2-1"></td>
+      <td id="square2-2"></td>
+      <td id="square2-3"></td>
+      <td id="square2-4"></td>
     </tr>
     <tr>
-      <td>
-        <a id="square3-0"></a>
-      </td>
-      <td>
-        <a id="square3-1"></a>
-      </td>
-      <td>
-        <a id="square3-2"></a>
-      </td>
-      <td>
-        <a id="square3-3"></a>
-      </td>
-      <td>
-        <a id="square3-4"></a>
-      </td>
+      <td id="square3-0"></td>
+      <td id="square3-1"></td>
+      <td id="square3-2"></td>
+      <td id="square3-3"></td>
+      <td id="square3-4"></td>
     </tr>
     <tr>
-      <td>
-        <a id="square4-0"></a>
-      </td>
-      <td>
-        <a id="square4-1"></a>
-      </td>
-      <td>
-        <a id="square4-2"></a>
-      </td>
-      <td>
-        <a id="square4-3"></a>
-      </td>
-      <td>
-        <a id="square4-4"></a>
-      </td>
+      <td id="square4-0"></td>
+      <td id="square4-1"></td>
+      <td id="square4-2"></td>
+      <td id="square4-3"></td>
+      <td id="square4-4"></td>
     </tr>
   </table>
   <div class="footer">

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     vertical-align: middle;
     width: 120px;
     height: 120px;
+    cursor: pointer;
   }
 
   a.selected {
@@ -62,11 +63,6 @@
     margin: 30px 0 30px 0;
     font-family: 'helvetica nueue', 'arial', sans-serif;
     color: #AAAAAA;
-  }
-
-  a {
-    text-decoration: none;
-    cursor: pointer;
   }
 
   .footer a {


### PR DESCRIPTION
Minor styling changes and make the entire squares clickable instead of child anchor elements.

Also added `.selected` styling which seems to be missing from the repo: 

![screen shot 2014-05-22 at 10 57 37](https://cloud.githubusercontent.com/assets/938453/3049348/dc784e66-e15c-11e3-957a-235b596bc6dc.png)
